### PR TITLE
fix: Order album playback by track number

### DIFF
--- a/app/src/main/java/com/sosauce/chocola/presentation/components/MusicViewModel.kt
+++ b/app/src/main/java/com/sosauce/chocola/presentation/components/MusicViewModel.kt
@@ -38,6 +38,7 @@ import com.sosauce.chocola.domain.actions.PlaySource
 import com.sosauce.chocola.domain.actions.PlayerActions
 import com.sosauce.chocola.utils.changeRepeatMode
 import com.sosauce.chocola.utils.copyMutate
+import com.sosauce.chocola.utils.orderAlbumTrackNumber
 import com.sosauce.chocola.utils.pauseWithFadeOut
 import com.sosauce.chocola.utils.playOrPause
 import com.sosauce.chocola.utils.playRandom
@@ -410,7 +411,7 @@ class MusicViewModel(
 
                 val targetTracks = when (val source = action.source) {
                     is PlaySource.All -> currentTracks
-                    is PlaySource.Album -> currentTracks.fastFilter { it.album == source.name }
+                    is PlaySource.Album -> currentTracks.fastFilter { it.album == source.name }.orderAlbumTrackNumber()
                     is PlaySource.Artist -> currentTracks.fastFilter { it.artist == source.name }
                     is PlaySource.ExplicitTracks -> source.tracks
                 }
@@ -564,7 +565,7 @@ class MusicViewModel(
 
                 val targetTracks = when (val source = action.source) {
                     is PlaySource.All -> currentTracks
-                    is PlaySource.Album -> currentTracks.fastFilter { it.album == source.name }
+                    is PlaySource.Album -> currentTracks.fastFilter { it.album == source.name }.orderAlbumTrackNumber()
                     is PlaySource.Artist -> currentTracks.fastFilter { it.artist == source.name }
                     is PlaySource.ExplicitTracks -> source.tracks
                 }


### PR DESCRIPTION
Since version 4.4.0 there has been a regression where album next/prev seeking ignores track metadata and the playback becomes alphabetical.

Before patch:
https://github.com/user-attachments/assets/d06cdb81-d862-47ed-b651-11e8758215a1

After patch:
https://github.com/user-attachments/assets/bb0c3d9d-c182-4fa2-8971-d654f88e24f8

AI Disclousure: While I'm a programmer, I have never worked on an android app. To help myself I've used AI to create this patch.

Also again big thanks for creating this awesome app ❤️